### PR TITLE
Improve modal focus handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -141,13 +141,16 @@ document.addEventListener("DOMContentLoaded", () => {
             ${usdPrice ? `<div class="product-price" aria-label="سعر المنتج: ${usdPrice} دولار">$${usdPrice}</div>` : ""}
           </div>
         `
-        productCard.addEventListener("click", () => openProductModal(product))
+        productCard.addEventListener("click", (e) => openProductModal(product, e.currentTarget))
         productsGrid.appendChild(productCard)
       })
     }
   }
 
-  function openProductModal(product) {
+  let openerElement = null
+
+  function openProductModal(product, opener) {
+    openerElement = opener || document.activeElement
     const adjustedBRL = transformPrice(product.price).toFixed(2)
     const usdPrice = convertToUSD(adjustedBRL)
 
@@ -191,7 +194,10 @@ document.addEventListener("DOMContentLoaded", () => {
   function closeProductModal() {
     productModal.style.display = "none"
     // إعادة التركيز إلى العنصر الذي فتح النافذة المنبثقة
-    if (document.activeElement) {
+    if (openerElement) {
+      openerElement.focus()
+      openerElement = null
+    } else if (document.activeElement) {
       document.activeElement.focus()
     }
   }


### PR DESCRIPTION
## Summary
- track the opener element when showing a product modal
- return focus to that opener after closing

## Testing
- `node -c main.js`

------
https://chatgpt.com/codex/tasks/task_e_68403dddd9ec83308f74cc48d1b49635