### PR TITLE
Refactor pricing utilities and add tests

### DIFF
--- a/__tests__/pricing.test.ts
+++ b/__tests__/pricing.test.ts
@@ -1,0 +1,39 @@
+import { transformPrice, convertToUSD } from '../lib/pricing'
+
+describe('transformPrice', () => {
+  it('returns 0 for invalid input', () => {
+    expect(transformPrice('abc')).toBe(0)
+  })
+
+  it('applies 4.2x for prices below 20', () => {
+    expect(transformPrice(10)).toBeCloseTo(42)
+  })
+
+  it('applies 3.2x for prices between 20 and 50 inclusive', () => {
+    expect(transformPrice(20)).toBeCloseTo(64)
+    expect(transformPrice(50)).toBeCloseTo(160)
+  })
+
+  it('applies 2.5x for prices above 50 and below 60', () => {
+    expect(transformPrice(55)).toBeCloseTo(137.5)
+  })
+
+  it('applies 2x for prices >=60 and <106', () => {
+    expect(transformPrice(70)).toBeCloseTo(140)
+  })
+
+  it('applies 1.5x for prices >=106', () => {
+    expect(transformPrice(110)).toBeCloseTo(165)
+  })
+})
+
+describe('convertToUSD', () => {
+  it('returns empty string for invalid input', () => {
+    expect(convertToUSD('abc' as any, 0.2)).toBe('')
+  })
+
+  it('converts BRL to USD using provided rate and rounds up to one decimal', () => {
+    expect(convertToUSD(50, 0.2)).toBe('10.0')
+  })
+})
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { products } from "@/data/products"
+import { transformPrice, convertToUSD } from "@/lib/pricing"
 
 export default function Home() {
   const [searchTerm, setSearchTerm] = useState("")
@@ -68,22 +69,6 @@ export default function Home() {
     setFilteredProducts(filtered)
   }, [searchTerm, selectedBrand, selectedLine, selectedCategory])
 
-  // Transform price function
-  const transformPrice = (priceBRL) => {
-    if (!priceBRL || isNaN(priceBRL)) return 0
-    const base = Number.parseFloat(priceBRL)
-    if (base >= 106) return base * 1.5
-    if (base >= 60) return base * 2
-    if (base < 20) return base * 4.2
-    return base <= 50 ? base * 3.2 : base * 2.5
-  }
-
-  // Convert to USD function
-  const convertToUSD = (brlAmount) => {
-    if (!brlAmount || isNaN(brlAmount)) return ""
-    const value = Number.parseFloat(brlAmount) * usdRate
-    return (Math.ceil(value * 10) / 10).toFixed(1)
-  }
 
   // Open product modal
   const openProductModal = (product) => {
@@ -190,7 +175,7 @@ export default function Home() {
               <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
                 {filteredProducts.map((product, index) => {
                   const adjustedBRL = transformPrice(product.price).toFixed(2)
-                  const usdPrice = convertToUSD(adjustedBRL)
+                  const usdPrice = convertToUSD(adjustedBRL, usdRate)
 
                   return (
                     <ProductCard
@@ -239,7 +224,10 @@ export default function Home() {
       {selectedProduct && (
         <ProductModal
           product={selectedProduct}
-          usdPrice={convertToUSD(transformPrice(selectedProduct.price).toFixed(2))}
+          usdPrice={convertToUSD(
+            transformPrice(selectedProduct.price).toFixed(2),
+            usdRate
+          )}
           isOpen={isModalOpen}
           onClose={() => setIsModalOpen(false)}
         />

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -1,0 +1,23 @@
+export function transformPrice(priceBRL: number | string): number {
+  if (priceBRL === undefined || priceBRL === null || isNaN(Number(priceBRL))) return 0;
+  const base = parseFloat(String(priceBRL));
+  if (base >= 106) return base * 1.5;
+  if (base >= 60) return base * 2;
+  if (base < 20) return base * 4.2;
+  return base <= 50 ? base * 3.2 : base * 2.5;
+}
+
+export function convertToUSD(brlAmount: number | string, usdRate: number): string {
+  if (
+    brlAmount === undefined ||
+    brlAmount === null ||
+    isNaN(Number(brlAmount)) ||
+    usdRate === undefined ||
+    usdRate === null ||
+    isNaN(Number(usdRate))
+  ) {
+    return "";
+  }
+  const value = parseFloat(String(brlAmount)) * usdRate;
+  return (Math.ceil(value * 10) / 10).toFixed(1);
+}

--- a/main.js
+++ b/main.js
@@ -1,3 +1,5 @@
+import { transformPrice, convertToUSD } from "./lib/pricing.js";
+
 document.addEventListener("DOMContentLoaded", () => {
   // تحديث السنة الحالية في التذييل
   document.getElementById("current-year").textContent = new Date().getFullYear()
@@ -75,21 +77,6 @@ document.addEventListener("DOMContentLoaded", () => {
     categoryFilter.appendChild(option)
   })
 
-  function transformPrice(priceBRL) {
-    if (!priceBRL || isNaN(priceBRL)) return 0
-    const base = Number.parseFloat(priceBRL)
-    if (base >= 106) return base * 1.5
-    if (base >= 60) return base * 2
-    if (base < 20) return base * 4.2
-    return base <= 50 ? base * 3.2 : base * 2.5
-  }
-
-  function convertToUSD(brlAmount) {
-    if (!brlAmount || isNaN(brlAmount)) return ""
-    const usdRate = 1 / 5.2
-    const value = Number.parseFloat(brlAmount) * usdRate
-    return (Math.ceil(value * 10) / 10).toFixed(1)
-  }
 
   function filterAndDisplayProducts() {
     const searchTerm = searchInput.value.toLowerCase()
@@ -120,7 +107,7 @@ document.addEventListener("DOMContentLoaded", () => {
       productsGrid.innerHTML = ""
       filteredProducts.forEach((product) => {
         const adjustedBRL = transformPrice(product.price).toFixed(2)
-        const usdPrice = convertToUSD(adjustedBRL)
+        const usdPrice = convertToUSD(adjustedBRL, 1 / 5.2)
         const productCard = document.createElement("div")
         productCard.className = "product-card"
         productCard.setAttribute("tabindex", "0")
@@ -149,7 +136,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   function openProductModal(product) {
     const adjustedBRL = transformPrice(product.price).toFixed(2)
-    const usdPrice = convertToUSD(adjustedBRL)
+    const usdPrice = convertToUSD(adjustedBRL, 1 / 5.2)
 
     // إضافة سمات ARIA للنافذة المنبثقة
     productModal.setAttribute("role", "dialog")

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -62,11 +63,14 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.14",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "jest": "^29.7.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
+    "ts-jest": "^29.3.4",
     "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary
- extract pricing helpers into `lib/pricing.ts`
- import helpers in the Next.js page and in `main.js`
- set up Jest with ts-jest
- add unit tests for pricing helpers
- expose `npm test` script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68403de855e483308feadc4447f8d455