### PR TITLE
Add HTTPS server option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,18 @@ pnpm run start
 ```
 
 The server listens on the port defined in `.env.local` (defaults to `3000`).
-When deployed on your AWS instance (e.g. `18.228.211.21`) you can access the
+When deployed on your AWS instance (e.g. `56.125.95.223`) you can access the
 site using `http://<server-ip>:<port>`.
+
+If you need HTTPS, generate certificates in a directory named `cert` and start
+the server with:
+
+```bash
+pnpm run start:https
+```
+
+This launches `server-https.js` which wraps the Next.js app with Node's HTTPS
+server. The `cert` folder should contain `fullchain.pem` and `privkey.pem`.
 
 ## Deploying on AWS
 
@@ -85,11 +95,14 @@ site using `http://<server-ip>:<port>`.
 
    The app will listen on the port you specified in `.env.local`.
 
-3. **Point the front end** to your server by editing the snippet in `index.html` so it matches your server's IP address and port, for example:
+3. **Point the front end** to your server by editing the snippet in `index.html` so it matches your server's IP address and port:
 
    ```html
    <script>
-     window.CHAT_API_URL = "http://18.228.211.21:3000/api/chat"
+     const CHAT_HOST = "56.125.95.223"
+     const CHAT_PORT = "3000"
+     const protocol = location.protocol === "https:" ? "https" : "http"
+     window.CHAT_API_URL = `${protocol}://${CHAT_HOST}:${CHAT_PORT}/api/chat`
    </script>
    ```
 
@@ -103,7 +116,10 @@ bottom of `index.html` and replace the port if necessary:
 
 ```html
 <script>
-  window.CHAT_API_URL = "http://18.228.211.21:3000/api/chat"
+  const CHAT_HOST = "56.125.95.223"
+  const CHAT_PORT = "3000"
+  const protocol = location.protocol === "https:" ? "https" : "http"
+  window.CHAT_API_URL = `${protocol}://${CHAT_HOST}:${CHAT_PORT}/api/chat`
 </script>
 ```
 

--- a/index.html
+++ b/index.html
@@ -411,8 +411,10 @@
   </div>
 
   <script>
-    // Update the URL below if you change the server port
-    window.CHAT_API_URL = "http://56.125.95.223:3000/api/chat"
+    const CHAT_HOST = "56.125.95.223"
+    const CHAT_PORT = "3000"
+    const protocol = location.protocol === "https:" ? "https" : "http"
+    window.CHAT_API_URL = `${protocol}://${CHAT_HOST}:${CHAT_PORT}/api/chat`
   </script>
   <script src="products.js"></script>
   <script src="main.js"></script>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "start:https": "node server-https.js",
     "lint": "next lint",
     "test": "jest"
   },

--- a/server-https.js
+++ b/server-https.js
@@ -1,0 +1,23 @@
+const { createServer } = require('https');
+const { readFileSync } = require('fs');
+const next = require('next');
+
+const dev = process.env.NODE_ENV !== 'production';
+const app = next({ dev });
+const handle = app.getRequestHandler();
+
+const PORT = process.env.PORT || 3000;
+const CERT_DIR = process.env.CERT_DIR || 'cert';
+
+app.prepare().then(() => {
+  const options = {
+    key: readFileSync(`${CERT_DIR}/privkey.pem`),
+    cert: readFileSync(`${CERT_DIR}/fullchain.pem`),
+  };
+
+  createServer(options, (req, res) => {
+    handle(req, res);
+  }).listen(PORT, () => {
+    console.log(`> Ready on https://localhost:${PORT}`);
+  });
+});


### PR DESCRIPTION
## Summary
- add optional HTTPS server script using Node's https module
- document how to start the HTTPS server in README
- expose new `start:https` script in package.json

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_68409d858ac0833085c101aa140e252d