### PR TITLE
Add model selection and limit chat context

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,14 @@ This repository contains the source code for the Naturae Syria website and chatb
 
    ```bash
    OPENAI_API_KEY=your-api-key
+   OPENAI_MODEL=gpt-3.5-turbo
+   PRODUCT_CONTEXT_LIMIT=30
    PORT=3000
-   ```
+  ```
+
+`OPENAI_MODEL` sets which model to use (defaults to `gpt-3.5-turbo`).
+`PRODUCT_CONTEXT_LIMIT` controls how many products are included in each
+request to keep the token count below OpenAI's limit.
 
 ### Product data
 
@@ -94,6 +100,9 @@ server. The `cert` folder should contain `fullchain.pem` and `privkey.pem`.
    ```
 
    The app will listen on the port you specified in `.env.local`.
+
+  The startup output may display the machine's private IP address (e.g. `172.31.x.x`). This is normal—Next.js listens on all interfaces by default. Access the app from other devices using your server's public IP, e.g. `http://56.125.95.223:3000/`. You do **not** need to set `--hostname` to the public IP.
+
 
 3. **Point the front end** to your server by editing the snippet in `index.html` so it matches your server's IP address and port:
 

--- a/actions/chat-actions.ts
+++ b/actions/chat-actions.ts
@@ -5,8 +5,12 @@ const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 })
 
-function getProductsContext(): string {
+const OPENAI_MODEL = process.env.OPENAI_MODEL || "gpt-3.5-turbo"
+const PRODUCTS_LIMIT = parseInt(process.env.PRODUCT_CONTEXT_LIMIT || "30", 10)
+
+function getProductsContext(limit: number): string {
   return (products as any[])
+    .slice(0, limit)
     .map((product) => {
       return `
 اسم المنتج: ${product.name}
@@ -23,10 +27,10 @@ function getProductsContext(): string {
 }
 
 export async function getChatResponse(message: string): Promise<string> {
-  const productsContext = getProductsContext()
+  const productsContext = getProductsContext(PRODUCTS_LIMIT)
 
   const completion = await openai.chat.completions.create({
-    model: "gpt-3.5-turbo",
+    model: OPENAI_MODEL,
     messages: [
       {
         role: "system",


### PR DESCRIPTION
## Summary
- allow choosing OpenAI model via `OPENAI_MODEL`
- limit product context to avoid token overflow
- document new environment variables

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_6840a57cbd0c83309cf952bf45b4e1c8