### PR TITLE
Fix chat API URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -414,7 +414,7 @@
     const CHAT_HOST = "56.125.95.223"
     const CHAT_PORT = "3000"
     const protocol = location.protocol === "https:" ? "https" : "http"
-    window.CHAT_API_URL = `http://${CHAT_HOST}:${CHAT_PORT}/api/chat`
+    window.CHAT_API_URL = `${protocol}://${CHAT_HOST}:${CHAT_PORT}/api/chat`
   </script>
   <script src="products.js"></script>
   <script src="main.js"></script>


### PR DESCRIPTION
## Summary
- use the page protocol when building `CHAT_API_URL`

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_6840bcdbf9ec83309c5e297c2a21ddd1